### PR TITLE
Bump springframework.version from 5.0.6.RELEASE to 5.2.5.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <spring-boot.version>2.2.2.RELEASE</spring-boot.version>
         <start-class>nestpay.paperpay.App</start-class>
         <graal.version>19.2.1</graal.version>
-        <springframework.version>5.0.6.RELEASE</springframework.version>
+        <springframework.version>5.2.5.RELEASE</springframework.version>
 		<hibernate.version>5.4.1.Final</hibernate.version>
 		<mysql.connector.version>5.1.45</mysql.connector.version>
 		<c3po.version>0.9.5.2</c3po.version>


### PR DESCRIPTION
Bumps `springframework.version` from 5.0.6.RELEASE to 5.2.5.RELEASE.

Updates `spring-webmvc` from 5.0.6.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.6.RELEASE...v5.2.5.RELEASE)

Updates `spring-tx` from 5.0.6.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.6.RELEASE...v5.2.5.RELEASE)

Updates `spring-orm` from 5.0.6.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.6.RELEASE...v5.2.5.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>